### PR TITLE
Fix license

### DIFF
--- a/rpm-fedora/prime_server.spec
+++ b/rpm-fedora/prime_server.spec
@@ -4,7 +4,7 @@ Summary: non-blocking (web)server API for distributed computing and SOA based on
 Name: prime_server
 Version: 0.6.3
 Release: 1%{?dist}
-License: 'ambiguous' MIT
+License: BSD
 Group: Libraries/Network
 URL: https://github.com/kevinkreiser/prime_server
 

--- a/rpm/prime_server.spec
+++ b/rpm/prime_server.spec
@@ -2,7 +2,7 @@ Summary: non-blocking (web)server API for distributed computing and SOA based on
 Name: prime_server
 Version: 0.6.3
 Release: 1%{?dist}
-License: 'ambiguous' MIT
+License: BSD
 Group: Libraries/Network
 URL: https://github.com/kevinkreiser/prime_server
 


### PR DESCRIPTION
According to the author of prime_server[0], the project is licensed
under the BSD 2 clause license.

[0] https://github.com/kevinkreiser/prime_server/issues/70